### PR TITLE
Update Island.java

### DIFF
--- a/src/main/java/com/craftaro/skyblock/island/Island.java
+++ b/src/main/java/com/craftaro/skyblock/island/Island.java
@@ -918,7 +918,7 @@ public class Island {
 
         for (Entry<IslandRole, List<IslandPermission>> entry : this.islandPermissions.entrySet()) {
             for (IslandPermission permission : entry.getValue()) {
-                configLoad.set("Settings." + entry.getKey() + "." + permission.getPermission().getName(), permission.getStatus());
+                configLoad.set("Settings." + entry.getKey().getFriendlyName() + "." + permission.getPermission().getName(), permission.getStatus());
             }
         }
 


### PR DESCRIPTION
Island settings were not being saved because the role keys of the island settings were not called correctly.