### PR TITLE
Fix EnumLocalization.java

### DIFF
--- a/src/main/java/com/craftaro/skyblock/localization/type/impl/EnumLocalization.java
+++ b/src/main/java/com/craftaro/skyblock/localization/type/impl/EnumLocalization.java
@@ -37,6 +37,6 @@ public class EnumLocalization<T extends Enum<T>> extends Localization<T> {
     }
 
     protected T parseEnum(String input) {
-        return Enum.valueOf(getType(), input.toUpperCase());
+        return Enum.valueOf(getType(), input.toUpperCase(Locale.ENGLISH));
     }
 }


### PR DESCRIPTION
Since the Locale.ENGLISH value is not given to the String.toUppercase() method, the computer system changes the enum value in Turkish language such as Visitor to VISITOR instead of VISITOR, and an error occurs in the plugin.